### PR TITLE
Updating client go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	google.golang.org/protobuf v1.28.1
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
-	k8s.io/client-go v0.0.0-00010101000000-000000000000
+	k8s.io/client-go v0.26.1
 )
 
 require (


### PR DESCRIPTION
Adding this change as the following issue was observed

```
go get github.com/IBM/secret-common-lib
go: k8s.io/client-go@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```