### PR TITLE
Removing appended token exchange path

### DIFF
--- a/pkg/config/cluster_config.go
+++ b/pkg/config/cluster_config.go
@@ -117,9 +117,9 @@ func GetTokenExchangeURLfromStorageSecretStore(clusterInfo ClusterConfig, config
 	var url string
 	switch providerType {
 	case utils.VPC:
-		url = config.VPC.G2TokenExchangeURL + tokenExchangePath
+		url = config.VPC.G2TokenExchangeURL
 	case utils.Bluemix:
-		url = config.Bluemix.IamURL + tokenExchangePath
+		url = config.Bluemix.IamURL
 	case utils.Softlayer:
 		url = config.Softlayer.SoftlayerTokenExchangeURL
 	}


### PR DESCRIPTION
In the following code, the suffix is truncated if it exists
https://github.com/IBM/go-sdk-core/blob/d9ff2b571769b4435cf139ba4a2fa2d6837007fb/core/iam_authenticator.go#L257
https://github.com/IBM/go-sdk-core/blob/d9ff2b571769b4435cf139ba4a2fa2d6837007fb/core/container_authenticator.go#L257

On satellite clusters, at times, there are chances slclient.toml doesn't exist, hence keep bluemix.URL empty. In the code, if tokenExchangePath is appended to empty string here https://github.com/IBM/secret-utils-lib/pull/29/files#diff-e0de885dd0362c0f54b2dd82199283a00772e248b656ff1f5568b50775cca17fL122. The condition in this line - https://github.com/IBM/secret-utils-lib/pull/29/files#diff-e0de885dd0362c0f54b2dd82199283a00772e248b656ff1f5568b50775cca17fL127 will fail, which is unxpected. Hence, removing the token exchange path. sdk-core library takes care of appending it here - https://github.com/IBM/go-sdk-core/blob/d9ff2b571769b4435cf139ba4a2fa2d6837007fb/core/iam_authenticator.go#L400